### PR TITLE
Tweak Rails::Generators.hidden_namespaces so no RSpec generators are hidden...

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,10 +30,5 @@ module RspecRailsExamples
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
-
-    generators do |app|
-      ::Rails::Generators.hidden_namespaces.reject! { |namespace| namespace.start_with?("rspec") }
-    end
-
   end
 end

--- a/config/initializers/unhide_rspec_generators.rb
+++ b/config/initializers/unhide_rspec_generators.rb
@@ -1,0 +1,3 @@
+Rails.application.generators do |app|
+  ::Rails::Generators.hidden_namespaces.reject! { |namespace| namespace.start_with?("rspec") }
+end


### PR DESCRIPTION
... from command line help. When running "rails g", command line help now shows all RSpec generators:

Rspec:
  rspec:controller
  rspec:feature
  rspec:helper
  rspec:install
  rspec:integration
  rspec:job
  rspec:mailer
  rspec:model
  rspec:observer
  rspec:scaffold
  rspec:view
