### PR TITLE
Remove :type => :feature from feature specs

### DIFF
--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-feature "Home page", :type => :feature do
-  
+feature "Home page" do
+
   scenario "visit" do
     visit "/"
     expect(page).to have_title "Welcome to RSpec Rails Examples"

--- a/spec/features/share_page_spec.rb
+++ b/spec/features/share_page_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-feature "Share page", type: :feature, js: true do
-  
+feature "Share page", js: true do
+
   scenario "displays 3rd party widgets" do
     visit "/share"
     expect(page).to have_title "Share Our Stuff!"

--- a/spec/features/subscribe_to_newsletter_spec.rb
+++ b/spec/features/subscribe_to_newsletter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "Subscribe to newsletter", type: :feature do
+feature "Subscribe to newsletter" do
 
   context "in browser with native date input", driver: driver_with(native_date_input: true) do
 

--- a/spec/features/user_login_and_logout_spec.rb
+++ b/spec/features/user_login_and_logout_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "User logs in and logs out", :type => :feature do
+feature "User logs in and logs out" do
 
   # `js: true` spec metadata means this will run using the `:selenium`
   # browser driver configured in spec/support/capybara.rb

--- a/spec/features/user_registers_spec.rb
+++ b/spec/features/user_registers_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "User registers", :type => :feature do
+feature "User registers" do
 
   scenario "with valid details" do
 


### PR DESCRIPTION
From capybara docs:

  `feature` is in fact just an alias for `describe ..., :type => :feature`

https://github.com/jnicklas/capybara#using-capybara-with-rspec