### PR TITLE
Order Gemfile alphabetically

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,41 +1,36 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.1'
-gem 'sqlite3'
-gem 'sass-rails', '~> 4.0'
-gem 'uglifier', '>= 1.3.0'
+
 gem 'coffee-rails', '~> 4.1.0'
-gem 'jquery-rails'
-gem 'turbolinks'
 gem 'devise'
+gem 'jquery-rails'
 gem 'nokogiri'
+gem 'sass-rails', '~> 4.0'
+gem 'sqlite3'
+gem 'turbolinks'
+gem 'uglifier', '>= 1.3.0'
 
 group :development, :test do
   gem 'byebug' # Call 'byebug' in code to stop execution and get a debugger console
-  gem 'web-console', '~> 2.0' # Access IRB on error pages or by <%= console %> in views
-  gem 'spring' # Spring background-runs app in dev for speed
-  gem 'rspec-rails', '~> 3.2'
-
   gem 'capybara'
-
-  # selenium-webdriver & chromedriver-helper used by
-  # JavaScript-dependent feature specs (`js: true`):
-  gem 'selenium-webdriver'
-  gem 'chromedriver-helper'
-
-  gem 'puffing-billy'
-
+  gem 'chromedriver-helper' # used by JavaScript-dependent feature specs (`js: true`)
   gem 'factory_girl_rails', '~> 4.5'
   gem 'pry'
+  gem 'pry-rails'
   gem 'pry-rescue'
   gem 'pry-stack_explorer'
-  gem 'pry-rails'
+  gem 'puffing-billy'
+  gem 'rspec-rails', '~> 3.2'
+  gem 'selenium-webdriver' # used by JavaScript-dependent feature specs (`js: true`)
+  gem 'spring' # Spring background-runs app in dev for speed
+  gem 'web-console', '~> 2.0' # Access IRB on error pages or by <%= console %> in views
 end
 
 group :test do
+  gem 'database_cleaner'
   gem 'email_spec'
   gem 'shoulda-matchers', require: false
-  gem 'database_cleaner'
   gem 'vcr'
   gem 'webmock'
 end


### PR DESCRIPTION
Ordering the Gemfile in this way makes it easier to scan. It also avoids any confusion about where a new Gem entry should be placed.

* Exclude Rails from ordering since it is the core of the app.