### PR TITLE
Enable email_spec helpers+matchers for all specs

### DIFF
--- a/spec/support/email_spec.rb
+++ b/spec/support/email_spec.rb
@@ -13,8 +13,8 @@ require 'email_spec'
 
 RSpec.configure do |config|
 
-  config.include EmailSpec::Helpers, [type: :mailer, type: :feature, type: :job]
-  config.include EmailSpec::Matchers, [type: :mailer, type: :feature, type: :job]
+  config.include EmailSpec::Helpers
+  config.include EmailSpec::Matchers
 
   config.before(:each) do
     reset_mailer # Clears out ActionMailer::Base.deliveries


### PR DESCRIPTION
email_spec was being added to specs of type :mailer, :feature,
and :job. I also needed it in :request specs, so that would have
brought the total to 4 spec types being mentioned in the config for
email_spec, and this would likely grow in the future.

Now including email_spec in all spec types so its there when its
needed. Devs using this config in their own projects will not be
tripped up by email_spec not being available in some specs.

As a bonus, this fixes #45 "Fix email_spec.rb duplicate :type key
warnings"[0]

[0] https://github.com/eliotsykes/rspec-rails-examples/issues/45