### PR TITLE
Moved Rails web-console out of development-test group 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ group :development, :test do
   gem 'selenium-webdriver' # used by JavaScript-dependent feature specs (`js: true`)
   gem 'spring' # Spring background-runs app in dev for speed
   gem 'spring-commands-rspec' # Enable Spring for RSpec
+end
+
+group :development do
   gem 'web-console', '~> 2.0' # Access IRB on error pages or by <%= console %> in views
 end
 


### PR DESCRIPTION
Hey @eliotsykes,

Moved Rails web-console gem out of the development-test group in the Gemfile and into its own development group (you'll see this in Rails 5). If you run RSpec from the terminal, it will now break since the gem does not allow you to put it inside of a test group.

This is the error you will receive: 
```
Web Console is activated in the test environment, which is
usually a mistake. To ensure it's only activated in development
mode, move it to the development group of your Gemfile:

    gem 'web-console', group: :development

If you still want to run it the test environment (and know
what you are doing), put this in your Rails application
configuration:

    config.web_console.development_only = false
```

See https://github.com/rails/web-console/issues/150